### PR TITLE
Direct property manage card main click to edit page

### DIFF
--- a/frontend/src/components/property/PropertiesManagementPage.tsx
+++ b/frontend/src/components/property/PropertiesManagementPage.tsx
@@ -44,6 +44,7 @@ const PropertiesManagementPage: FC = () => {
                   propertyId={propertyId}
                   elevation={4}
                   showActions
+                  to={`/properties/${propertyId}/edit`}
                 />
               </Grid>
             ))}

--- a/frontend/src/components/property/PropertyCard.tsx
+++ b/frontend/src/components/property/PropertyCard.tsx
@@ -76,11 +76,13 @@ const CardActions = styled.div`
 interface PropertyCardProps extends PaperProps {
   propertyId: number;
   showActions?: boolean;
+  to?: string;
 }
 
 const PropertyCard: FC<PropertyCardProps> = ({
   propertyId,
   showActions,
+  to,
   ...paperProps
 }) => {
   const dispatch = useAppDispatch();
@@ -109,7 +111,7 @@ const PropertyCard: FC<PropertyCardProps> = ({
   return (
     <>
       <CardRoot {...paperProps}>
-        <CardLinkWrapper to={`/properties/${propertyId}`}>
+        <CardLinkWrapper to={to || `/properties/${propertyId}`}>
           {propertyImage && (
             <CardMedia
               style={{ backgroundImage: `url(${propertyImage.url})` }}
@@ -125,6 +127,9 @@ const PropertyCard: FC<PropertyCardProps> = ({
         </CardLinkWrapper>
         {showActions && (
           <CardActions>
+            <Button variant="text" as={Link} to={`/properties/${propertyId}`}>
+              View
+            </Button>
             <Button
               variant="text"
               as={Link}


### PR DESCRIPTION
This changes the functionality of the Property Card on the Manage page to link to the edit page of the property instead of the property's page. In doing so, a View button has been introduced to direct to the property's page.